### PR TITLE
feat: precede coingecko api request with reefscan api

### DIFF
--- a/src/components/Collectible/HeroSection.jsx
+++ b/src/components/Collectible/HeroSection.jsx
@@ -22,6 +22,7 @@ import { getBackend } from "@utils/network";
 import useStateInfo from "@utils/useStateInfo";
 import { useErrorModalHelper } from "@elements/Default/ErrorModal";
 import { REEF_PRICE_COINGECKO, REEF_PRICE_REEFSCAN } from "@constants/price";
+import { convertREEFtoUSD } from "@utils/convertREEFtoUSD";
 
 const Wrapper = styled.div`
 	padding: 0 6rem;
@@ -90,18 +91,11 @@ const HeroSection = () => {
 			const collectiblePromise = axios.get(
 				`${getBackend()}/get/marketplace/position/${addr}`
 			);
-			const pricePromise = axios(
-				REEF_PRICE_REEFSCAN
-			);
 			try {
 				let [collectible, price] = await Promise.all([
 					collectiblePromise,
-					pricePromise,
+					convertREEFtoUSD(1),
 				]);
-
-				if(price.error){
-					price = await axios.get(REEF_PRICE_COINGECKO);
-				}
 
 				if (collectible.data && collectible.data.error)
 					setCollectibleInfo({
@@ -109,10 +103,7 @@ const HeroSection = () => {
 						isValidCollectible: false,
 					});
 				else {
-					let conversionRate = price.data
-						? price.data["usd"]?price.data["usd"]:
-						price.data["reef"].usd
-						: 0;
+					let conversionRate = price;
 					setCollectibleInfo({
 						...collectible.data,
 						conversionRate,

--- a/src/components/Collectible/HeroSection.jsx
+++ b/src/components/Collectible/HeroSection.jsx
@@ -21,7 +21,6 @@ import styled from "styled-components";
 import { getBackend } from "@utils/network";
 import useStateInfo from "@utils/useStateInfo";
 import { useErrorModalHelper } from "@elements/Default/ErrorModal";
-import { REEF_PRICE_COINGECKO, REEF_PRICE_REEFSCAN } from "@constants/price";
 import { convertREEFtoUSD } from "@utils/convertREEFtoUSD";
 
 const Wrapper = styled.div`

--- a/src/constants/price.js
+++ b/src/constants/price.js
@@ -1,0 +1,7 @@
+const REEF_PRICE_REEFSCAN = "https://api.reefscan.info/price/reef";
+const REEF_PRICE_COINGECKO = "https://api.coingecko.com/api/v3/simple/price?ids=reef&vs_currencies=usd";
+
+module.exports = {
+    REEF_PRICE_COINGECKO,
+    REEF_PRICE_REEFSCAN
+}

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,17 +1,10 @@
 import Wrapper from "@components/Default/Wrapper";
-import React, { useEffect } from "react";
+import React from "react";
 import HeroSection from "@components/LandingRedesign/HeroSection";
 import useCheckJWT from "@utils/useCheckJWT";
-import { convertREEFtoUSD } from "@utils/convertREEFtoUSD";
 
 const Landing = () => {
 	useCheckJWT();
-	useEffect(()=>{
-		const fetcher = async()=>{
-			console.log(await convertREEFtoUSD(10))
-		}
-		fetcher()
-	},[])
 	return (
 		<Wrapper landing>
 			<HeroSection />

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,10 +1,17 @@
 import Wrapper from "@components/Default/Wrapper";
-import React from "react";
+import React, { useEffect } from "react";
 import HeroSection from "@components/LandingRedesign/HeroSection";
 import useCheckJWT from "@utils/useCheckJWT";
+import { convertREEFtoUSD } from "@utils/convertREEFtoUSD";
 
 const Landing = () => {
 	useCheckJWT();
+	useEffect(()=>{
+		const fetcher = async()=>{
+			console.log(await convertREEFtoUSD(10))
+		}
+		fetcher()
+	},[])
 	return (
 		<Wrapper landing>
 			<HeroSection />

--- a/src/utils/convertREEFtoUSD.js
+++ b/src/utils/convertREEFtoUSD.js
@@ -14,7 +14,7 @@ export const convertREEFtoUSD = async price => {
 			let conversionRate = res.data["reef"].usd ?? 0;
 			return Number(price) * Number(conversionRate);
 		} catch (error) {
-			return null;
+			return 0;
 		}
 	}
 };

--- a/src/utils/convertREEFtoUSD.js
+++ b/src/utils/convertREEFtoUSD.js
@@ -1,13 +1,20 @@
+import { REEF_PRICE_COINGECKO, REEF_PRICE_REEFSCAN } from "@constants/price";
 import axios from "axios";
 
 export const convertREEFtoUSD = async price => {
 	try {
-		let res = await axios(
-			"https://api.coingecko.com/api/v3/simple/price?ids=reef&vs_currencies=usd"
-		);
-		let conversionRate = res.data["reef"].usd;
-		return Number(price) * Number(conversionRate);
+		let res = await axios(REEF_PRICE_REEFSCAN);
+		let conversionRate = res.data["usd"] ?? 0;
+		if (conversionRate !== 0) {
+			return Number(price) * Number(conversionRate);
+		}
 	} catch (err) {
-		return null;
+		try {
+			let res = await axios(REEF_PRICE_COINGECKO);
+			let conversionRate = res.data["reef"].usd ?? 0;
+			return Number(price) * Number(conversionRate);
+		} catch (error) {
+			return null;
+		}
 	}
 };


### PR DESCRIPTION
- tries to fetch from reefscan api, if it works then return or else use coingecko price api
- using a single function throughout the client for fetching reef price in same manner
- convertREEFtoUSD(1) for fetching price of 1 REEF